### PR TITLE
Removed on Roll feature

### DIFF
--- a/src/redempt/redlib/misc/WeightedRandom.java
+++ b/src/redempt/redlib/misc/WeightedRandom.java
@@ -20,6 +20,8 @@ public class WeightedRandom<T> {
 	private List<Double> totals;
 	private List<T> items;
 	
+	private boolean removeOnRollFlag = false;
+	
 	/**
 	 * Create a new WeightedRandom from a map of outcomes to their weights
 	 * @param map The map of outcomes to their weights
@@ -84,6 +86,17 @@ public class WeightedRandom<T> {
 		total = 0;
 	}
 	
+	/**
+	 * Sets the removeOnRoll flag to true
+	 */
+	public void removeOnRoll() { this.removeOnRollFlag = true; }
+
+	/**
+	 * Sets the removeOnRollFlag
+	 */
+    	public void setRemoveOnRoll(boolean removeOnRoll) { this.removeOnRollFlag = removeOnRoll; }
+	
+	
 	private WeightedRandom(Map<T, Double> weights, boolean no) {
 		initialize(weights);
 	}
@@ -103,6 +116,23 @@ public class WeightedRandom<T> {
 	}
 	
 	/**
+	 * Remaps all the weights and items if removeOnRoll
+	 * is activated
+	 */
+	private void reMap(int index) {
+        	T rolled = items.get(index);
+        	Double rolledWeight = weights.get(rolled);
+
+        	total -= rolledWeight;
+        	totals.remove(index);
+        	IntStream.range(index, totals.size())
+                	.forEach(value ->
+                        	totals.set(index, totals.get(index) - rolledWeight));
+        	items.remove(index);
+       		weights.remove(rolled);
+    }
+	
+	/**
 	 * Rolls and gets a weighted random outcome
 	 * @return A weighted random outcome, or null if there are no possible outcomes
 	 */
@@ -116,7 +146,9 @@ public class WeightedRandom<T> {
 			pos = -(pos + 1);
 		}
 		pos = Math.min(pos, items.size() - 1);
-		return items.get(pos);
+		T rolled = items.get(pos);
+		if (removeOnRollFlag) reMap(pos);
+        	return rolled;
 	}
 	
 	/**


### PR DESCRIPTION
Option to enable removeOnRoll, which consist on removing the rolled object when calling roll() so is neved rolled again. I came to this problem in one of my projects, where i wanted a weightedRandom object from a collection but to never appear again. This could be also implemented from the api-user storing the rolled items and if the roll() output is contained, roll again, but i found this to be a better solution since my collection is not really that big.

To sum it up is not a big feature but i wanted to collaborate on the project since i found it really useful on my projects, thanks for all man!