### PR TITLE
add overload to CommandCollection#register that takes the Plugin instance explicitly

### DIFF
--- a/src/redempt/redlib/commandmanager/CommandCollection.java
+++ b/src/redempt/redlib/commandmanager/CommandCollection.java
@@ -22,6 +22,20 @@ public class CommandCollection {
 	public CommandCollection(List<Command> commands) {
 		this.commands = commands;
 	}
+
+	/**
+	 * Register all commands in this CommandCollection
+	 * @param plugin the plugin that owns the commands
+	 * @param prefix The fallback prefix of the commands
+	 * @param listeners The list of listener objects which contain hooks for the commands in this collection
+	 */
+	public void register(Plugin plugin, String prefix, Object... listeners) {
+		mergeBaseCommands();
+		commands.forEach(c -> {
+			c.plugin = plugin;
+			c.register(prefix, listeners);
+		});
+	}
 	
 	/**
 	 * Register all commands in this CommandCollection
@@ -29,12 +43,7 @@ public class CommandCollection {
 	 * @param listeners The list of listener objects which contain hooks for the commands in this collection
 	 */
 	public void register(String prefix, Object... listeners) {
-		mergeBaseCommands();
-		Plugin plugin = RedLib.getCallingPlugin();
-		commands.forEach(c -> {
-			c.plugin = plugin;
-			c.register(prefix, listeners);
-		});
+		register(RedLib.getCallingPlugin(), prefix, listeners);
 	}
 	
 	private void mergeBaseCommands() {


### PR DESCRIPTION
This makes it possible for Plugins that are not JavaPlugins to use this framework.

More details here: https://github.com/Jannyboy11/ScalaPluginLoader/issues/11