### PR TITLE
Fix properties bug in SQLHelper

### DIFF
--- a/src/redempt/redlib/sql/SQLHelper.java
+++ b/src/redempt/redlib/sql/SQLHelper.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 import java.util.function.Consumer;
 
 /**
@@ -28,7 +29,12 @@ public class SQLHelper implements Closeable {
 	public static Connection openSQLite(java.nio.file.Path file) {
 		try {
 			Class.forName("org.sqlite.JDBC");
-			return DriverManager.getConnection("jdbc:sqlite:" + file.toAbsolutePath() + "?foreign_keys=on&busy_timeout=1000");
+
+			final Properties properties = new Properties();
+			properties.setProperty("foreign_keys", "on");
+			properties.setProperty("busy_timeout", "1000");
+
+			return DriverManager.getConnection("jdbc:sqlite:" + file.toAbsolutePath(), properties);
 		} catch (ClassNotFoundException | SQLException e) {
 			sneakyThrow(e);
 			return null;


### PR DESCRIPTION
Fixes error `The filename, directory name, or volume label syntax is incorrect` with SQLHelper in RedLib.