### PR TITLE
Remove lore functionality

### DIFF
--- a/src/redempt/redlib/itemutils/ItemBuilder.java
+++ b/src/redempt/redlib/itemutils/ItemBuilder.java
@@ -101,6 +101,26 @@ public class ItemBuilder extends ItemStack {
 		ItemUtils.addLore(this, lines);
 		return this;
 	}
+
+	/**
+	 * Remove a String of lore if present from this ItemBuilder
+	 * @param line The line of lore to remove
+	 * @return The ItemBuilder with lore removed if present
+	 */
+	public ItemBuilder removeLore(String line) {
+		ItemUtils.removeLoreLine(this, line);
+		return this;
+	}
+
+	/**
+	 * Remove a line of lore if present from this ItemBuilder
+	 * @param index The index of the line of lore to remove
+	 * @return The ItemBuilder with lore removed if present
+	 */
+	public ItemBuilder removeLore(int index) {
+		ItemUtils.removeLoreLine(this, index);
+		return this;
+	}
 	
 	/**
 	 * Renames this ItemBuilder

--- a/src/redempt/redlib/itemutils/ItemUtils.java
+++ b/src/redempt/redlib/itemutils/ItemUtils.java
@@ -148,7 +148,6 @@ public class ItemUtils {
 	public static ItemStack removeLoreLine(ItemStack item, String line){
 		ItemMeta meta = item.getItemMeta();
 		List<String> lore = new ArrayList<>(meta.getLore());
-		if(!lore.contains(line)) return item;
 		lore.remove(line);
 		meta.setLore(lore);
 		item.setItemMeta(meta);
@@ -164,7 +163,9 @@ public class ItemUtils {
 	public static ItemStack removeLoreLine(ItemStack item, int index){
 		ItemMeta meta = item.getItemMeta();
 		List<String> lore = new ArrayList<>(meta.getLore());
-		if(index < 0 || index > lore.size()) return item;
+		if (index < 0 || index > lore.size()) {
+                    throw new IllegalArgumentException("Value out of bounds (" + n + ")");
+                }
 		lore.remove(index);
 		meta.setLore(lore);
 		item.setItemMeta(meta);

--- a/src/redempt/redlib/itemutils/ItemUtils.java
+++ b/src/redempt/redlib/itemutils/ItemUtils.java
@@ -181,8 +181,6 @@ public class ItemUtils {
 	public static ItemStack setLore(ItemStack item, String... lore) {
 		return setLore(item, Arrays.asList(lore));
 	}
-
-
 	
 	/**
 	 * Sets an item to be unbreakable

--- a/src/redempt/redlib/itemutils/ItemUtils.java
+++ b/src/redempt/redlib/itemutils/ItemUtils.java
@@ -147,7 +147,7 @@ public class ItemUtils {
 	 */
 	public static ItemStack removeLoreLine(ItemStack item, String line){
 		ItemMeta meta = item.getItemMeta();
-		List<String> lore = new ArrayList<>(meta.getLore());
+		List<String> lore = meta.getLore();
 		lore.remove(line);
 		meta.setLore(lore);
 		item.setItemMeta(meta);
@@ -162,7 +162,7 @@ public class ItemUtils {
 	 */
 	public static ItemStack removeLoreLine(ItemStack item, int index){
 		ItemMeta meta = item.getItemMeta();
-		List<String> lore = new ArrayList<>(meta.getLore());
+		List<String> lore = meta.getLore();
 		if (index < 0 || index > lore.size()) {
                     throw new IllegalArgumentException("Value out of bounds (" + n + ")");
                 }

--- a/src/redempt/redlib/itemutils/ItemUtils.java
+++ b/src/redempt/redlib/itemutils/ItemUtils.java
@@ -138,6 +138,38 @@ public class ItemUtils {
 		item.setItemMeta(meta);
 		return item;
 	}
+
+	/**
+	 * Remove a specific line of lore from an ItemStack if present in an ItemStack
+	 * @param item The ItemStack to remove lore from
+	 * @param line The line of lore to remove
+	 * @return The modified ItemStack
+	 */
+	public static ItemStack removeLoreLine(ItemStack item, String line){
+		ItemMeta meta = item.getItemMeta();
+		List<String> lore = new ArrayList<>(meta.getLore());
+		if(!lore.contains(line)) return item;
+		lore.remove(line);
+		meta.setLore(lore);
+		item.setItemMeta(meta);
+		return item;
+	}
+
+	/**
+	 * Removes a specific index-line of lore from an ItemStack if present in an ItemStack
+	 * @param item The ItemStack to remove lore from
+	 * @param index The index of the line of lore to remove
+	 * @return The modified ItemStack
+	 */
+	public static ItemStack removeLoreLine(ItemStack item, int index){
+		ItemMeta meta = item.getItemMeta();
+		List<String> lore = new ArrayList<>(meta.getLore());
+		if(index < 0 || index > lore.size()) return item;
+		lore.remove(index);
+		meta.setLore(lore);
+		item.setItemMeta(meta);
+		return item;
+	}
 	
 	/**
 	 * Set multiple lines of lore for an ItemStack
@@ -148,6 +180,8 @@ public class ItemUtils {
 	public static ItemStack setLore(ItemStack item, String... lore) {
 		return setLore(item, Arrays.asList(lore));
 	}
+
+
 	
 	/**
 	 * Sets an item to be unbreakable


### PR DESCRIPTION
Added four new methods with documentation. In ItemUtils I added removing lore from an itemstack with either a specific lore line or index of the line. This will do nothing if the lore line doesnt exist or index is out of bounds. I implemented this into ItemBuilder but I don't know how useful that'll be.