### PR TITLE
Add check for zero amount

### DIFF
--- a/src/redempt/redlib/itemutils/ItemUtils.java
+++ b/src/redempt/redlib/itemutils/ItemUtils.java
@@ -618,7 +618,7 @@ public class ItemUtils {
      * @return Whether the item is empty
      */
     public static boolean isEmpty(ItemStack item) {
-        return item == null || item.getType() == Material.AIR;
+        return item == null || item.getType() == Material.AIR || item.getAmount() <= 0;
     }
 
     /**


### PR DESCRIPTION
Better match Paper's isEmpty method: `type.isAir() || amount <= 0`.
We can keep `type == AIR` because the other air types are not present in the inventory.